### PR TITLE
refactor: split error handling

### DIFF
--- a/server/src/common/error.rs
+++ b/server/src/common/error.rs
@@ -1,151 +1,15 @@
-use std::borrow::Cow;
+pub mod api;
+pub mod database;
+pub mod service;
 
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    Json,
-};
-use sea_orm::{DbErr, SqlErr};
-use serde_json::json;
-use thiserror::Error;
-use validator::ValidationErrors;
-
-pub type ApiResult<T> = Result<T, ApiError>;
-pub type ServiceResult<T> = Result<T, ServiceError>;
-
-#[derive(Debug, Error)]
-pub enum ApiError {
-    #[error("unauthorized")]
-    Unauthorized(&'static str),
-    #[error("forbidden")]
-    Forbidden(&'static str),
-    #[error("not found")]
-    NotFound(&'static str),
-    #[error("bad request")]
-    BadRequest(String),
-    #[error("conflict")]
-    Conflict(&'static str),
-    #[error(transparent)]
-    Internal(#[from] anyhow::Error),
-}
-
-#[derive(Debug, Error)]
-pub enum ServiceError {
-    #[error("resource not found")]
-    NotFound,
-    #[error("resource already exists")]
-    AlreadyExists,
-    #[error("validation error")]
-    ValidationError,
-    #[error("database error")]
-    DatabaseError(#[from] DatabaseError),
-}
-
-#[derive(Debug, Error)]
-pub enum DatabaseError {
-    #[error("record not found")]
-    NotFound,
-    #[error("unique constraint violation")]
-    Conflict,
-    #[error("operation failed")]
-    OperationFailed,
-    #[error("internal database error")]
-    Internal,
-}
-
-impl From<DbErr> for DatabaseError {
-    fn from(err: DbErr) -> Self {
-        use DatabaseError::*;
-
-        match &err {
-            DbErr::RecordNotFound(_) => NotFound,
-            _ if matches!(err.sql_err(), Some(SqlErr::UniqueConstraintViolation(_))) => Conflict,
-
-            DbErr::ConnectionAcquire(_)
-            | DbErr::Conn(_)
-            | DbErr::RecordNotInserted
-            | DbErr::RecordNotUpdated
-            | DbErr::AttrNotSet(_)
-            | DbErr::Query(_)
-            | DbErr::Exec(_) => OperationFailed,
-
-            _ => Internal,
-        }
-    }
-}
-
-impl From<DbErr> for ServiceError {
-    fn from(err: DbErr) -> Self {
-        ServiceError::DatabaseError(err.into())
-    }
-}
-
-impl From<ValidationErrors> for ApiError {
-    fn from(err: ValidationErrors) -> Self {
-        ApiError::BadRequest(err.to_string())
-    }
-}
-
-impl From<ServiceError> for ApiError {
-    fn from(err: ServiceError) -> Self {
-        match err {
-            ServiceError::NotFound => ApiError::NotFound("resource not found".into()),
-            ServiceError::AlreadyExists => ApiError::Conflict("resource already exists".into()),
-            ServiceError::ValidationError => ApiError::BadRequest("validation failed".into()),
-            ServiceError::DatabaseError(db) => match db {
-                DatabaseError::NotFound => ApiError::NotFound("resource not found".into()),
-                DatabaseError::Conflict => ApiError::Conflict("resource already exists".into()),
-                DatabaseError::OperationFailed => ApiError::BadRequest("operation failed".into()),
-                DatabaseError::Internal => {
-                    ApiError::Internal(anyhow::anyhow!("database internal error"))
-                }
-            },
-        }
-    }
-}
-
-impl ApiError {
-    fn status(&self) -> StatusCode {
-        use ApiError::*;
-        match self {
-            Unauthorized(_) => StatusCode::UNAUTHORIZED,
-            Forbidden(_) => StatusCode::FORBIDDEN,
-            NotFound(_) => StatusCode::NOT_FOUND,
-            BadRequest(_) => StatusCode::BAD_REQUEST,
-            Conflict(_) => StatusCode::CONFLICT,
-            Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
-
-    fn client_msg(&self) -> Cow<'static, str> {
-        use ApiError::*;
-        match self {
-            Unauthorized(m) | Forbidden(m) | NotFound(m) | Conflict(m) => Cow::Borrowed(m),
-            BadRequest(m) => Cow::Owned(m.clone()),
-            Internal(_) => Cow::Borrowed("an internal error occurred"),
-        }
-    }
-}
-
-impl IntoResponse for ApiError {
-    fn into_response(self) -> Response {
-        let status = self.status();
-        (
-            status,
-            Json(json!({
-                "error": {
-                    "status": status.as_u16(),
-                    "message": self.client_msg(),
-                }
-            })),
-        )
-            .into_response()
-    }
-}
+pub use api::{ApiError, ApiResult};
+pub use database::DatabaseError;
+pub use service::{ServiceError, ServiceResult};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::StatusCode;
     use sea_orm::DbErr;
 
     #[test]
@@ -160,14 +24,5 @@ mod tests {
             let api_err: ApiError = service_err.into();
             assert_eq!(api_err.status(), expected_status);
         }
-    }
-
-    #[test]
-    fn validation_maps_to_bad_request() {
-        let mut ve = ValidationErrors::new();
-        ve.add("field", validator::ValidationError::new("invalid"));
-        let api_err: ApiError = ve.into();
-
-        assert_eq!(api_err.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/server/src/common/error/api.rs
+++ b/server/src/common/error/api.rs
@@ -1,0 +1,114 @@
+use std::borrow::Cow;
+
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+use thiserror::Error;
+use validator::ValidationErrors;
+
+use super::{database::DatabaseError, service::ServiceError};
+
+pub type ApiResult<T> = Result<T, ApiError>;
+
+#[derive(Debug, Error)]
+pub enum ApiError {
+    #[error("unauthorized")]
+    Unauthorized(&'static str),
+    #[error("forbidden")]
+    Forbidden(&'static str),
+    #[error("not found")]
+    NotFound(&'static str),
+    #[error("bad request")]
+    BadRequest(String),
+    #[error("conflict")]
+    Conflict(&'static str),
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
+}
+
+impl From<ValidationErrors> for ApiError {
+    fn from(err: ValidationErrors) -> Self {
+        ApiError::BadRequest(err.to_string())
+    }
+}
+
+impl From<ServiceError> for ApiError {
+    fn from(err: ServiceError) -> Self {
+        match err {
+            ServiceError::NotFound => ApiError::NotFound("resource not found"),
+            ServiceError::AlreadyExists => ApiError::Conflict("resource already exists"),
+            ServiceError::ValidationError => ApiError::BadRequest("validation failed".into()),
+            ServiceError::DatabaseError(db) => match db {
+                DatabaseError::NotFound => ApiError::NotFound("resource not found"),
+                DatabaseError::Conflict => ApiError::Conflict("resource already exists"),
+                DatabaseError::OperationFailed => ApiError::BadRequest("operation failed".into()),
+                DatabaseError::Internal => {
+                    ApiError::Internal(anyhow::anyhow!("database internal error"))
+                }
+            },
+        }
+    }
+}
+
+impl ApiError {
+    pub fn status(&self) -> StatusCode {
+        use ApiError::*;
+        match self {
+            Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            Forbidden(_) => StatusCode::FORBIDDEN,
+            NotFound(_) => StatusCode::NOT_FOUND,
+            BadRequest(_) => StatusCode::BAD_REQUEST,
+            Conflict(_) => StatusCode::CONFLICT,
+            Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn client_msg(&self) -> Cow<'static, str> {
+        use ApiError::*;
+        match self {
+            Unauthorized(m) | Forbidden(m) | NotFound(m) | Conflict(m) => Cow::Borrowed(m),
+            BadRequest(m) => Cow::Owned(m.clone()),
+            Internal(_) => Cow::Borrowed("an internal error occurred"),
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = self.status();
+        (
+            status,
+            Json(json!({
+                "error": {
+                    "status": status.as_u16(),
+                    "message": self.client_msg(),
+                }
+            })),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_maps_to_bad_request() {
+        let mut ve = ValidationErrors::new();
+        ve.add("field", validator::ValidationError::new("invalid"));
+        let api_err: ApiError = ve.into();
+
+        assert_eq!(api_err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn service_error_maps_to_correct_status() {
+        let service_err = ServiceError::NotFound;
+        let api_err: ApiError = service_err.into();
+        assert_eq!(api_err.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/server/src/common/error/database.rs
+++ b/server/src/common/error/database.rs
@@ -1,0 +1,71 @@
+use sea_orm::{sqlx, DbErr, RuntimeErr, SqlErr};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DatabaseError {
+    #[error("record not found")]
+    NotFound,
+    #[error("unique constraint violation")]
+    Conflict,
+    #[error("operation failed")]
+    OperationFailed,
+    #[error("internal database error")]
+    Internal,
+}
+
+impl From<DbErr> for DatabaseError {
+    fn from(err: DbErr) -> Self {
+        use DatabaseError::*;
+
+        match &err {
+            DbErr::RecordNotFound(_) => NotFound,
+
+            _ if is_unique_constraint_violation(&err) => Conflict,
+
+            DbErr::Exec(RuntimeErr::SqlxError(sqlx_err))
+            | DbErr::Query(RuntimeErr::SqlxError(sqlx_err)) => handle_sqlx_error(sqlx_err),
+
+            DbErr::ConnectionAcquire(_)
+            | DbErr::Conn(_)
+            | DbErr::RecordNotInserted
+            | DbErr::RecordNotUpdated
+            | DbErr::AttrNotSet(_)
+            | DbErr::Query(_)
+            | DbErr::Exec(_) => OperationFailed,
+
+            _ => Internal,
+        }
+    }
+}
+
+fn is_unique_constraint_violation(err: &DbErr) -> bool {
+    matches!(err.sql_err(), Some(SqlErr::UniqueConstraintViolation(_)))
+}
+
+fn handle_sqlx_error(sqlx_err: &sqlx::Error) -> DatabaseError {
+    match sqlx_err {
+        sqlx::Error::Database(db_err) => handle_database_error_code(db_err.code().as_deref()),
+        _ => DatabaseError::OperationFailed,
+    }
+}
+
+fn handle_database_error_code(code: Option<&str>) -> DatabaseError {
+    match code {
+        Some("42P01") => DatabaseError::Internal, // undefined_table
+        Some("42703") => DatabaseError::Internal, // undefined_column
+        Some("42883") => DatabaseError::Internal, // undefined_function
+        _ => DatabaseError::OperationFailed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_not_found_maps_correctly() {
+        let db_err = DbErr::RecordNotFound("Record not found".to_string());
+        let database_error: DatabaseError = db_err.into();
+        assert!(matches!(database_error, DatabaseError::NotFound));
+    }
+}

--- a/server/src/common/error/service.rs
+++ b/server/src/common/error/service.rs
@@ -1,0 +1,36 @@
+use sea_orm::DbErr;
+use thiserror::Error;
+
+use super::database::DatabaseError;
+
+pub type ServiceResult<T> = Result<T, ServiceError>;
+
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    #[error("resource not found")]
+    NotFound,
+    #[error("resource already exists")]
+    AlreadyExists,
+    #[error("validation error")]
+    ValidationError,
+    #[error("database error")]
+    DatabaseError(#[from] DatabaseError),
+}
+
+impl From<DbErr> for ServiceError {
+    fn from(err: DbErr) -> Self {
+        ServiceError::DatabaseError(err.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_err_maps_to_service_error() {
+        let db_err = DbErr::RecordNotFound("Record not found".to_string());
+        let service_err: ServiceError = db_err.into();
+        assert!(matches!(service_err, ServiceError::DatabaseError(_)));
+    }
+}


### PR DESCRIPTION
Split error handling

What:
- split error types into separate modules
- improve database error mapping

Why: to handle schema issues correctly and better maintainability